### PR TITLE
Fix bug in aircraft details insertion

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,21 +169,21 @@ if nav_bar == "Aircraft Details":
     with st.form("aircrafts_form", clear_on_submit=True):
         aircraft_code = st.text_input(label="Aircraft Code:", value="")
         model = st.text_input(label="Aircraft Model:", value="")
-        range = st.text_input(label="Range:", value="")
+        aircraft_range = st.text_input(label="Range:", value="")
 
         "---"
         aircraft_submit = st.form_submit_button("Save Aircraft")
         if aircraft_submit:
             st.write("Aircraft Code:",aircraft_code)
             st.write("Aircraft Model:", model)
-            st.write("Range:", range)
+            st.write("Range:", aircraft_range)
             #connect to database
             conn = connect_to_database()
             if conn is None:
                 st.error("Failed to connect to the database.")
             else:
                 # Save flight details to the database
-                if insert_aircraft_details(conn, aircraft_code, model, range):
+                if insert_aircraft_details(conn, aircraft_code, model, aircraft_range):
                     st.success("Aircraft details saved!")
                 else:
                     st.error("Failed to save aircraft details. Please try again later.")

--- a/database_conn.py
+++ b/database_conn.py
@@ -87,7 +87,7 @@ def insert_airport_details(conn, airport_code, airport_name, city, airport_timez
         return False
 
 
-def insert_aircraft_details(conn, aircraft_code, model, range):
+def insert_aircraft_details(conn, aircraft_code, model, aircraft_range):
     try:
         if conn is None:
             print("Database connection is not established.")
@@ -101,7 +101,7 @@ def insert_aircraft_details(conn, aircraft_code, model, range):
                                     VALUES (%s, %s, %s)"""
 
         # Execute the INSERT statement
-        cursor.execute(postgres_insert_query, (aircraft_code, model, range))
+        cursor.execute(postgres_insert_query, (aircraft_code, model, aircraft_range))
 
         # Commit the changes to the database
         conn.commit()
@@ -112,7 +112,7 @@ def insert_aircraft_details(conn, aircraft_code, model, range):
         return True  # Return True if insertion is successful
     
     except (Exception, psycopg2.DatabaseError) as error:
-        print("Error while inserting airport details:", error)
+        print("Error while inserting aircraft details:", error)
         return False
     
 #fetch query


### PR DESCRIPTION
## Summary
- avoid using built-in `range` name when inserting aircraft details
- adjust app to use new `aircraft_range` field
- clarify error message for aircraft insertion

## Testing
- `python3 -m py_compile app.py database_conn.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9b6dd1488321831e431a4930f328